### PR TITLE
update the const LDAPAuthDomain to have type AuthDomain

### DIFF
--- a/types.go
+++ b/types.go
@@ -325,7 +325,7 @@ type AuthDomain string
 
 const (
 	InternalAuthDomain AuthDomain = "local"
-	LDAPAuthDomain                = "ldap"
+	LDAPAuthDomain     AuthDomain = "ldap"
 )
 
 type User struct {


### PR DESCRIPTION
in a const section, each new const does not inherit previous line's type;

https://play.golang.org/p/_vp5ROMdP6f

```go
	fmt.Printf("%[1]T %#[1]v\n", InternalAuthDomain)
	fmt.Printf("%[1]T %#[1]v\n", LDAPAuthDomain)
```

runs

```
main.AuthDomain "local"
string "ldap"
```